### PR TITLE
[KDL-3] daemon-reload 태스크 추가

### DIFF
--- a/roles/mariadb/tasks/package.yml
+++ b/roles/mariadb/tasks/package.yml
@@ -22,3 +22,7 @@
   with_items:
     - replication-manager
   when: ansible_fqdn in groups['replication_manager']
+
+- name: Just force systemd to reread configs
+  systemd:
+    daemon_reload: yes


### PR DESCRIPTION
MariaDB 재설치 과정에서 mariadb not found 에러가 발생하기 때문에
package 설치 후 daemon reload 과정을 추가합니다.