### PR TITLE
[KDL-52] clean-mariadb 파일 생성

### DIFF
--- a/clean-mariadb.yml
+++ b/clean-mariadb.yml
@@ -1,0 +1,11 @@
+- include: stop-mariadb.yml
+
+- hosts: mariadb:replication_manager
+  user: root
+  max_fail_percentage: 0
+  vars_files:
+    - group_vars/mariadb.yml
+
+  tasks:
+  - include: roles/mariadb/tasks/cleanall.yml
+


### PR DESCRIPTION
기존 mariadb-playbook의 roles/mariadb/tasks/cleanall.yml 를 사용하기 위해
해당 파일을 include하는 yml파일을 작성합니다.